### PR TITLE
UX: remove deprecated component, style maintenance

### DIFF
--- a/about.json
+++ b/about.json
@@ -21,7 +21,6 @@
     }
   },
   "components": [
-    "https://github.com/discourse/discourse-loading-slider.git",
     "https://github.com/discourse/discourse-search-banner.git"
   ]
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -45,3 +45,7 @@ input[type="color"]:focus,
   box-shadow: none;
   outline: none;
 }
+
+.nav-pills > li a.active::after {
+  display: none;
+}

--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -25,7 +25,6 @@ body.has-sidebar-page {
       .sidebar-section-content
       .sidebar-section-link-wrapper,
     .sidebar-more-section-links-details {
-      padding-left: 1em;
       .sidebar-section-link {
         &:hover,
         &:focus,


### PR DESCRIPTION
Removes the deprecated loading slider component and fixes a couple minor style issues


Before:
![before](https://github.com/user-attachments/assets/3237cfaa-3ebf-4afd-b30f-c8330a33041c)


After: 
![image](https://github.com/user-attachments/assets/85ba8a91-c9e9-4ea4-8f33-7dc29f6306c2)
